### PR TITLE
fix mock error caused by invalid username

### DIFF
--- a/src/mock/users.js
+++ b/src/mock/users.js
@@ -61,7 +61,7 @@ module.exports = {
     const { username, password } = req.body
     const user = adminUsers.filter((item) => item.username === username)
 
-    if (user && user[0].password === password) {
+    if (user[0] && user[0].password === password) {
       const now = new Date()
       now.setDate(now.getDate() + 1)
       res.cookie('token', JSON.stringify({ id: user[0].id, deadline: now.getTime() }), {


### PR DESCRIPTION
如果使用不存在的用户名登录（比如"user"），会使mock返回500错误，`npm run dev`也会报异常。