### PR TITLE
fix YQL bugs:the chat '&' doesn't encoded

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -50,7 +50,7 @@ const fetch = (options) => {
       })
     })
   } else if (fetchType === 'YQL') {
-    url = `http://query.yahooapis.com/v1/public/yql?q=select * from json where url='${options.url}?${qs.stringify(options.data)}'&format=json`
+    url = `http://query.yahooapis.com/v1/public/yql?q=select * from json where url='${options.url}?${encodeURIComponent(qs.stringify(options.data))}'&format=json`
     data = null
   }
 


### PR DESCRIPTION
When the remote url have more than one param,the '&' will be considered as the param of the yql's param unless you encode it