### PR TITLE
Update app.js

### DIFF
--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -82,7 +82,11 @@ const App = ({ children, location, dispatch, app, loading }) => {
       </Helmet>
       <div className={classnames(styles.layout, { [styles.fold]: isNavbar ? false : siderFold }, { [styles.withnavbar]: isNavbar })}>
         {!isNavbar ? <aside className={classnames(styles.sider, { [styles.light]: !darkTheme })}>
-          <Sider {...siderProps} />
+          {siderProps.menu.length === 0 ?
+            null
+            :
+            <Sider {...siderProps} />
+          }
         </aside> : ''}
         <div className={styles.main}>
           <Header {...headerProps} />


### PR DESCRIPTION
先判断menu长度,解决当远程加载menu时刷新页面,当前位置不会选中