### PR TITLE
enable custom the className for Iconfont

### DIFF
--- a/src/components/Iconfont/Iconfont.js
+++ b/src/components/Iconfont/Iconfont.js
@@ -1,21 +1,38 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 import './iconfont.less'
 
-const Iconfont = ({ type, colorful }) => {
+const Iconfont = ({ type, colorful, className }) => {
+  const propsClassName = className;
+
+  const csSvg = classnames(
+    { 'colorful-icon': true },
+    { [`${propsClassName}`]: className !== undefined },
+  );
+
   if (colorful) {
-    return (<span
-      dangerouslySetInnerHTML={{
-        __html: `<svg class="colorful-icon" aria-hidden="true"><use xlink:href="#${type.startsWith('#') ? type.replace(/#/, '') : type}"></use></svg>`,
-      }}
-    />)
+    return (
+      <svg className={csSvg} aria-hidden="true">
+        <use xlinkHref={`#${type.startsWith('#') ? type.replace(/#/, '') : type}`} />
+      </svg>
+    );
   }
-  return <i className={`antdadmin icon-${type}`} />
+  const csFont = classnames(
+    { antdadmin: true },
+    { [`icon-${type}`]: true },
+    { [`${propsClassName}`]: className !== undefined },
+  );
+  return <i className={csFont} />;
 }
 
 Iconfont.propTypes = {
-  type: PropTypes.string,
+  type: PropTypes.string.isRequired,
   colorful: PropTypes.bool,
+}
+
+Iconfont.defaultProps = {
+  colorful: false,
 }
 
 export default Iconfont

--- a/src/routes/UIElement/iconfont/index.js
+++ b/src/routes/UIElement/iconfont/index.js
@@ -23,13 +23,12 @@ const localRequireSVGIcons = [
   require('../../../svg/cute/sweat.svg'),
   require('../../../svg/cute/think.svg'),
 ]
-
 const IcoPage = () => <div className="content-inner">
   <Icon type="star-o" />
   <h2 style={{ margin: '16px 0' }}>Colorful Icon</h2>
   <ul className={styles.list}>
     {colorfulIcons.map(item => <li key={item}>
-      <Iconfont className={styles.icon} colorful type={item} />
+      <Iconfont className={styles.colorfulIcon} colorful type={item} />
       <span className={styles.name}>{item}</span>
     </li>)}
   </ul>
@@ -43,14 +42,14 @@ const IcoPage = () => <div className="content-inner">
   <h2 style={{ margin: '16px 0' }}>Local SVG</h2>
   <ul className={styles.list}>
     {localSVGIcons.map(item => <li key={item}>
-      <Iconfont className={styles.icon} colorful type={item} />
+      <Iconfont className={styles.colorfulIcon} colorful type={item} />
       <span className={styles.name}>{item}</span>
     </li>)}
   </ul>
   <h2 style={{ margin: '16px 0' }}>Local Require SVG</h2>
   <ul className={styles.list}>
     {localRequireSVGIcons.map(item => <li key={item}>
-      <Iconfont className={styles.icon} colorful type={item} />
+      <Iconfont className={styles.colorfulIcon} colorful type={item} />
       <span className={styles.name}>{item}</span>
     </li>)}
   </ul>

--- a/src/routes/UIElement/iconfont/index.js
+++ b/src/routes/UIElement/iconfont/index.js
@@ -25,7 +25,7 @@ const localRequireSVGIcons = [
 ]
 
 const IcoPage = () => <div className="content-inner">
-  <Icon type="star-oo" />
+  <Icon type="star-o" />
   <h2 style={{ margin: '16px 0' }}>Colorful Icon</h2>
   <ul className={styles.list}>
     {colorfulIcons.map(item => <li key={item}>

--- a/src/routes/UIElement/iconfont/index.less
+++ b/src/routes/UIElement/iconfont/index.less
@@ -26,15 +26,13 @@
     margin-top: 8px;
   }
 
-  :global {
-    .colorful-icon {
-      font-size: 36px;
-    }
+  .colorfulIcon {
+    font-size: 36px;
+  }
 
-    .antdadmin {
-      font-size: 32px;
-      line-height: 1;
-    }
+  .icon {
+    font-size: 32px;
+    line-height: 1;
   }
 }
 @media (min-width: 1600px) {


### PR DESCRIPTION
- Refactor the `src/components/Iconfont/Iconfont.js`, enable the className for custom styles.
- More details shows in the code && the commit notes.
- And the Usage is updated to `src/routes/UIElement/iconfont/index.js` and `src/routes/UIElement/iconfont/index.less`.

thanks.