### PR TITLE
Update app.js

### DIFF
--- a/src/models/app.js
+++ b/src/models/app.js
@@ -43,11 +43,8 @@ export default {
           yield put(routerRedux.push('/dashboard'))
         }
       } else {
-        if (location.pathname !== '/login') {
+        if (config.openPages && config.openPages.indexOf(location.pathname) < 0) {
           let from = location.pathname
-          if (location.pathname === '/dashboard') {
-            from = '/dashboard'
-          }
           window.location = `${location.origin}/login?from=${from}`
         }
       }


### PR DESCRIPTION
如果在config.js中添加了openPages，比如openPages: ['/login', '/home']，但是进入/home页面仍然要先登录，所以在app model中如果query不成功需要判断当前页面是否被设置成openPages，再决定是否跳转到/login