### PR TITLE
fixed:when click breadcrumb back to other page,the left menu displaye…

### DIFF
--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -108,6 +108,7 @@ const Menus = ({ siderFold, darkTheme, location, handleClickNavMenu, navOpenKeys
       mode={siderFold ? 'vertical' : 'inline'}
       theme={darkTheme ? 'dark' : 'light'}
       onClick={handleClickNavMenu}
+      selectedKeys={defaultSelectedKeys}
       defaultSelectedKeys={defaultSelectedKeys}
     >
       {menuItems}

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -89,12 +89,12 @@ export default function request (options) {
   return fetch(options).then((response) => {
     const { statusText, status } = response
     let data = options.fetchType === 'YQL' ? response.data.query.results.json : response.data
-    return {
+    return Promise.resolve({
       success: true,
       message: statusText,
       statusCode: status,
       ...data,
-    }
+    })
   }).catch((error) => {
     const { response } = error
     let msg
@@ -107,6 +107,6 @@ export default function request (options) {
       statusCode = 600
       msg = error.message || 'Network Error'
     }
-    return { success: false, statusCode, message: msg }
+    return Promise.reject({ success: false, statusCode, message: msg })
   })
 }


### PR DESCRIPTION
**修复问题**
1.当点击面包屑的**Dashboard**的时候，页面已经跳转到Dashboard界面，但是左边菜单仍然显示的是**上一次**的选择的菜单项;
2.request 请求时，如果是错误的请求，应该在catch方法中被捕获;现在的问题是，如果后台报500的错误请求，仍然在then方法中被捕获。