### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "react-dom": "^15.6.1",
     "react-draft-wysiwyg": "^1.10.0",
     "react-helmet": "^5.1.3",
-    "recharts": "^0.22.4",
-    "roadhog": "^1.2.1"
+    "recharts": "^0.22.4"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -50,7 +49,7 @@
     "html-webpack-plugin": "^2.29.0",
     "html-webpack-template": "^5.6.0",
     "redbox-react": "^1.2.10",
-    "roadhog": "1.0.0-beta.7"
+    "roadhog": "^1.2.1"
   },
   "pre-commit": ["lint"],
   "scripts": {


### PR DESCRIPTION
解决因package.json中roadhog配置，导致执行roadhog buildDll时显示“Module not found: Error: Can't resolve 'roadhog'”且compile失败的问题。