### PR TITLE
修复 4.3.5 中用户画面翻页无效的问题

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -24,9 +24,10 @@ export default modelExtend(pageModel, {
     setup ({ dispatch, history }) {
       history.listen((location) => {
         if (location.pathname === '/user') {
+          const payload = location.query || { current: 1, pageSize: 10 }
           dispatch({
             type: 'query',
-            payload: queryString.parse(location.search),
+            payload,
           })
         }
       })


### PR DESCRIPTION
4.3.5 中user的model在query的时候使用的是location.search, 但是location.search是空的，导致翻页无效，在线demo也有这个问题，我改成使用location.query了，测试下来是可以的，请您确认一下。