### PR TITLE
Fixed dark theme menu bug

### DIFF
--- a/src/components/Layout/Layout.less
+++ b/src/components/Layout/Layout.less
@@ -249,7 +249,10 @@
 
   .ant-menu-item-selected {
     color: @primary-color;
-    background-color: @dark-half;
+
+    &.ant-menu-item {
+      background: @dark-half;
+    }
 
     & > a {
       color: @primary-color;


### PR DESCRIPTION
在 dark 主题的时候，收起侧边栏，选中的菜单背景显示有bug，看不到文字了。

![wechatimg2](https://user-images.githubusercontent.com/13075469/30315813-c63e1c8a-976a-11e7-9622-8cc83ae888c7.jpeg)
