### PR TITLE
修复左侧菜单合拢时mouseover提示空白视觉bug

### DIFF
--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -33,7 +33,7 @@ const Menus = ({ siderFold, darkTheme, navOpenKeys, changeOpenKeys, menu, locati
         <Menu.Item key={item.id}>
           <Link to={item.route || '#'}>
             {item.icon && <Icon type={item.icon} />}
-            {(!siderFoldN || !menuTree.includes(item)) && item.name}
+            {item.name}
           </Link>
         </Menu.Item>
       )


### PR DESCRIPTION
当一级菜单没子菜单时，mouseover会弹出tooltips，但提示空白无内容