### PR TITLE
fix:进入动态路由下的二级页面菜单栏无法选中问题

### DIFF
--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -111,6 +111,8 @@ const Menus = ({
 
   if (!defaultSelectedKeys) {
     defaultSelectedKeys = ['1']
+  } else if(defaultSelectedKeys[0] === '-1') {
+    defaultSelectedKeys = [defaultSelectedKeys[1].toString()[0]]
   }
 
   return (


### PR DESCRIPTION
进入/user/xxxx时，菜单栏选择效果会丢失。