### PR TITLE
Bugfix/sidebar shake

### DIFF
--- a/src/components/Layout/Layout.less
+++ b/src/components/Layout/Layout.less
@@ -108,6 +108,14 @@
   }
 }
 
+.sidemenu {
+  :global{
+    .ant-menu-item {
+      width: 100%;
+    }  
+  }  
+}
+
 .switchtheme {
   width: 100%;
   position: absolute;

--- a/src/components/Layout/Layout.less
+++ b/src/components/Layout/Layout.less
@@ -25,6 +25,11 @@
     }
 
     .ant-menu {
+      &.ant-menu-inline {
+        .ant-menu-item {
+          width: 100%;
+        }
+      }
       .ant-menu-item,
       .ant-menu-submenu-title {
         overflow: hidden;

--- a/src/components/Layout/Layout.less
+++ b/src/components/Layout/Layout.less
@@ -25,11 +25,6 @@
     }
 
     .ant-menu {
-      &.ant-menu-inline {
-        .ant-menu-item {
-          width: 100%;
-        }
-      }
       .ant-menu-item,
       .ant-menu-submenu-title {
         overflow: hidden;

--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -4,6 +4,7 @@ import { Menu, Icon } from 'antd'
 import { Link } from 'react-router-dom'
 import { arrayToTree, queryArray } from 'utils'
 import pathToRegexp from 'path-to-regexp'
+import styles from './Layout.less'
 
 const { SubMenu } = Menu
 let openKeysFlag = false
@@ -123,6 +124,7 @@ const Menus = ({
       mode={siderFold ? 'vertical' : 'inline'}
       theme={darkTheme ? 'dark' : 'light'}
       selectedKeys={defaultSelectedKeys}
+      className={styles.sidemenu}
     >
       {menuItems}
     </Menu>


### PR DESCRIPTION
现在的侧边栏只要有鼠标放到上面就会晃动，原因是menu-item的宽度被设置成了100%+1。 我做了一些修改把宽度改成100%了。 这个修改只影响到侧边栏，不会影响到其他的ant-menu元素。

