### PR TITLE
Bugfix/motion switch

### DIFF
--- a/src/components/Layout/Layout.less
+++ b/src/components/Layout/Layout.less
@@ -58,11 +58,6 @@
       width: 22px;
       height: 22px;
     }
-
-    &.ant-switch-checked:after,
-    &.ant-switch-checked:before {
-      margin-left: -23px;
-    }
   }
 
   .flex-vertical-center {


### PR DESCRIPTION
Users页面右上角有一个motion switch，点击切换之后样式有问题，里面的小圆圈停在中间不动了。因为这个switch比其他的要大一些，css代码里有一些定制化的样式，其中就有调整圆圈位置的代码。可能现在这个版本的switch代码改动的，之前的fix不就需要了。

至于这个开关究竟是开启什么功能，我还不知道。 只是看到打开之后表格的大小改变了。