### PR TITLE
fix: 在ie11中因为flex的bug导致无法垂直居中显示modal

### DIFF
--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -46,7 +46,7 @@ class User extends PureComponent {
       title: `${
         modalType === 'create' ? i18n.t`Create User` : i18n.t`Update User`
       }`,
-      wrapClassName: 'vertical-center-modal',
+      centered: true,
       onOk(data) {
         dispatch({
           type: `user/${modalType}`,

--- a/src/themes/index.less
+++ b/src/themes/index.less
@@ -63,21 +63,6 @@ body {
     box-shadow: 0 0 20px rgba(100, 100, 100, 0.2);
   }
 
-  .vertical-center-modal {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    .ant-modal {
-      top: 0;
-
-      .ant-modal-body {
-        max-height: 80vh;
-        overflow-y: auto;
-      }
-    }
-  }
-
   .ant-form-item-control {
     vertical-align: middle;
   }


### PR DESCRIPTION
![modal](https://user-images.githubusercontent.com/15656042/49097614-11b06300-f2a8-11e8-812a-f5c56691db0c.png)
使用antd中Modal组件的centered属性，修复在ie11中无法居中显示modal的问题