### PR TITLE
fix: 关闭弹窗时有动画效果

### DIFF
--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -41,6 +41,7 @@ class User extends PureComponent {
     const modalProps = {
       item: modalType === 'create' ? {} : currentItem,
       visible: modalVisible,
+      destroyOnClose: true,
       maskClosable: false,
       confirmLoading: loading.effects[`user/${modalType}`],
       title: `${
@@ -163,7 +164,7 @@ class User extends PureComponent {
           </Row>
         )}
         <List {...listProps} />
-        {modalVisible && <Modal {...modalProps} />}
+        <Modal {...modalProps} />
       </Page>
     )
   }


### PR DESCRIPTION
`{modalVisible && <Modal {...modalProps} />}`这种方法强制更新modal，导致关闭弹窗时动画消失了