### PR TITLE
fix: request custom domain error issue

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -17,7 +17,7 @@ export default function request(options) {
     const urlMatch = url.match(/[a-zA-z]+:\/\/[^/]*/)
     if (urlMatch) {
       [domain] = urlMatch
-      url = url.slice(urlMatch.index)
+      url = url.slice(urlMatch.index + domain.length)
     }
 
     const match = pathToRegexp.parse(url)

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -16,8 +16,8 @@ export default function request(options) {
     let domain = ''
     const urlMatch = url.match(/[a-zA-z]+:\/\/[^/]*/)
     if (urlMatch) {
-      ;[domain] = urlMatch
-      url = url.slice(domain.length)
+      [domain] = urlMatch
+      url = url.slice(urlMatch.index)
     }
 
     const match = pathToRegexp.parse(url)


### PR DESCRIPTION
If my custom api url is "http://localhost:3000/model",  this script is matched url result is "st:3000/model", but this wrong.  Expect result is  "http://localhost:3000/model".