### PR TITLE
[fix] add notification popup to #primaryLayout instead of #layoutHeader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-admin",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "MIT",
   "description": "An admin dashboard application demo built upon Ant Design and UmiJS",
   "dependencies": {

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -85,7 +85,7 @@ class Header extends PureComponent {
         trigger="click"
         key="notifications"
         overlayClassName={styles.notificationPopover}
-        getPopupContainer={() => document.querySelector('#layoutHeader')}
+        getPopupContainer={() => document.querySelector('#primaryLayout')}
         content={
           <div className={styles.notification}>
             <List


### PR DESCRIPTION
Explain here -> https://github.com/zuiidea/antd-admin/issues/968#issuecomment-514880031