### PR TITLE
fix: 修复 antd 组件无法国际化的问题

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -5,23 +5,25 @@ import { i18n } from "@lingui/core"
 import { I18nProvider } from '@lingui/react'
 import { getLocale } from 'utils'
 import { zh, en, pt } from 'make-plural/plurals'
-import zh_CN from 'antd/lib/locale-provider/zh_CN'
-import en_US from 'antd/lib/locale-provider/en_US'
-import pt_BR from 'antd/lib/locale-provider/pt_BR'
+import zhCN from 'antd/lib/locale-provider/zh_CN'
+import enUS from 'antd/lib/locale-provider/en_US'
+import ptBR from 'antd/lib/locale-provider/pt_BR'
 
 import BaseLayout from './BaseLayout'
 
-const plurals =  {
-  zh,
-  en,
-  'pt-br': pt,
+i18n.loadLocaleData({
+  en: { plurals: en },
+  zh: { plurals: zh },
+  'pt-br': { plurals: pt }
+})
+
+// antd
+const languages = {
+  zh: zhCN,
+  en: enUS,
+  'pt-br': ptBR
 }
 
-const languages = {
-  zh: zh_CN,
-  en: en_US,
-  'pt-br': pt_BR,
-}
 const { defaultLanguage } = i18n
 
 @withRouter
@@ -29,50 +31,29 @@ class Layout extends Component {
   state = {
   }
 
-  language = defaultLanguage
-
   componentDidMount() {
-    const language = getLocale()
-    this.language = language
-    language && this.loadCatalog(language)
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    const language = getLocale()
-    const preLanguage = this.language
-
-    if (preLanguage !== language && !languages[language]) {
-      language && this.loadCatalog(language)
-      this.language = language
-      return false
-    }
-    this.language = language
-
-    return true
-  }
-
-  loadCatalog = async language => {
+  loadCatalog = async (lan) => {
     const catalog = await import(
-      `../locales/${language}/messages.json`
+      `../locales/${lan}/messages.json`
     )
 
-    i18n.load(language, catalog)
-    i18n.activate(language)
+    i18n.load(lan, catalog)
+    i18n.activate(lan)
   }
 
   render() {
     const { children } = this.props
 
     let language = getLocale()
-    // If the language pack is not loaded or is loading, use the default language
+
     if (!languages[language]) language = defaultLanguage
 
-    i18n.loadLocaleData(language, { plurals: plurals[language] })
-    i18n.load(language, languages[language])
-    i18n.activate(language)
+    this.loadCatalog(language)
 
     return (
-      <ConfigProvider locale={language}>
+      <ConfigProvider locale={languages[language]}>
         <I18nProvider i18n={i18n}>
           <BaseLayout>{children}</BaseLayout>
         </I18nProvider>


### PR DESCRIPTION
使用过中发现 `src/locales` 下定义的国际化配置无法和 antd 组件国际化同时起作用。翻找代码后，定位到 `src/layouts/index.js` 下存在 `i18n.load` 调用冲突的问题。现将 `componentDidMount` 中的 `loadCatalog` 调用去除，问题则得到修复。