### PR TITLE
Security: Sensitive AI provider API keys stored in localStorage

### DIFF
--- a/src/pages/ai/aiConfig.ts
+++ b/src/pages/ai/aiConfig.ts
@@ -50,6 +50,31 @@ export const DEFAULT_SETTINGS: AISettings = {
   providers: DEFAULT_CONFIG,
 };
 
+function sanitizeProviders(providers?: Partial<ConfigState>): ConfigState {
+  return {
+    openai: {
+      ...DEFAULT_CONFIG.openai,
+      ...(providers?.openai || {}),
+      apiKey: '',
+    },
+    qwen: {
+      ...DEFAULT_CONFIG.qwen,
+      ...(providers?.qwen || {}),
+      apiKey: '',
+    },
+    deepseek: {
+      ...DEFAULT_CONFIG.deepseek,
+      ...(providers?.deepseek || {}),
+      apiKey: '',
+    },
+    custom: {
+      ...DEFAULT_CONFIG.custom,
+      ...(providers?.custom || {}),
+      apiKey: '',
+    },
+  };
+}
+
 export function loadAISettings(): AISettings {
   try {
     const raw = localStorage.getItem(AI_SETTINGS_STORAGE_KEY);
@@ -65,10 +90,7 @@ export function loadAISettings(): AISettings {
         activeProvider === 'custom'
           ? activeProvider
           : 'openai',
-      providers: {
-        ...DEFAULT_CONFIG,
-        ...(parsed.providers || {}),
-      },
+      providers: sanitizeProviders(parsed.providers),
     };
   } catch (error) {
     return DEFAULT_SETTINGS;
@@ -76,7 +98,13 @@ export function loadAISettings(): AISettings {
 }
 
 export function saveAISettings(settings: AISettings) {
-  localStorage.setItem(AI_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  localStorage.setItem(
+    AI_SETTINGS_STORAGE_KEY,
+    JSON.stringify({
+      ...settings,
+      providers: sanitizeProviders(settings.providers),
+    }),
+  );
 }
 
 export function loadAIConfig(): ConfigState {


### PR DESCRIPTION
## Problem

AI provider credentials (including `apiKey`) are persisted in `localStorage` via `saveAISettings`. Any XSS in the application or third-party script execution can read and exfiltrate these secrets. localStorage is not appropriate for long-lived sensitive tokens/keys.

**Severity**: `high`
**File**: `src/pages/ai/aiConfig.ts`

## Solution

Do not store raw API keys in browser localStorage. Move model-provider calls behind a backend proxy and keep provider secrets server-side. If client-side storage is unavoidable, reduce risk with short-lived scoped tokens, strict CSP, and avoid persisting secrets at rest.

## Changes

- `src/pages/ai/aiConfig.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
